### PR TITLE
Ability to specify charset for the serial device

### DIFF
--- a/androidBluetoothSerial/src/main/java/com/harrysoft/androidbluetoothserial/BluetoothManager.java
+++ b/androidBluetoothSerial/src/main/java/com/harrysoft/androidbluetoothserial/BluetoothManager.java
@@ -61,7 +61,7 @@ public class BluetoothManager implements Closeable {
     /**
      * @param mac The MAC address of the device
      *             you are trying to connect to
-     * @param charset The Charset to use to decode incoming stream
+     * @param charset The Charset to use for input/output streams
      * @return An RxJava Single, that will either emit
      *          a BluetoothSerialDevice or a BluetoothConnectException
      */

--- a/androidBluetoothSerial/src/main/java/com/harrysoft/androidbluetoothserial/BluetoothManager.java
+++ b/androidBluetoothSerial/src/main/java/com/harrysoft/androidbluetoothserial/BluetoothManager.java
@@ -9,6 +9,7 @@ import java.io.Closeable;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -54,6 +55,17 @@ public class BluetoothManager implements Closeable {
      *          a BluetoothSerialDevice or a BluetoothConnectException
      */
     public Single<BluetoothSerialDevice> openSerialDevice(String mac) {
+        return openSerialDevice(mac, Charset.defaultCharset());
+    }
+
+    /**
+     * @param mac The MAC address of the device
+     *             you are trying to connect to
+     * @param charset The Charset to use to decode incoming stream
+     * @return An RxJava Single, that will either emit
+     *          a BluetoothSerialDevice or a BluetoothConnectException
+     */
+    public Single<BluetoothSerialDevice> openSerialDevice(String mac, Charset charset) {
         if (devices.containsKey(mac)) {
             return Single.just(devices.get(mac));
         } else {
@@ -63,7 +75,7 @@ public class BluetoothManager implements Closeable {
                     BluetoothSocket socket = device.createInsecureRfcommSocketToServiceRecord(UUID.fromString("00001101-0000-1000-8000-00805F9B34FB"));
                     adapter.cancelDiscovery();
                     socket.connect();
-                    BluetoothSerialDevice serialDevice = BluetoothSerialDevice.getInstance(mac, socket);
+                    BluetoothSerialDevice serialDevice = BluetoothSerialDevice.getInstance(mac, socket, charset);
                     devices.put(mac, serialDevice);
                     return serialDevice;
                 } catch (Exception e) {

--- a/androidBluetoothSerial/src/main/java/com/harrysoft/androidbluetoothserial/BluetoothSerialDevice.java
+++ b/androidBluetoothSerial/src/main/java/com/harrysoft/androidbluetoothserial/BluetoothSerialDevice.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.nio.charset.Charset;
 
 import io.reactivex.BackpressureStrategy;
 import io.reactivex.Completable;
@@ -22,19 +23,21 @@ public class BluetoothSerialDevice {
     private final BluetoothSocket socket;
     private final OutputStream outputStream;
     private final InputStream inputStream;
+    private final Charset charset;
 
     @Nullable
     private SimpleBluetoothDeviceInterface owner;
 
-    private BluetoothSerialDevice(String mac, BluetoothSocket socket, OutputStream outputStream, InputStream inputStream) {
+    private BluetoothSerialDevice(String mac, BluetoothSocket socket, OutputStream outputStream, InputStream inputStream, Charset charset) {
         this.mac = mac;
         this.socket = socket;
         this.outputStream = outputStream;
         this.inputStream = inputStream;
+        this.charset = charset;
     }
 
-    static BluetoothSerialDevice getInstance(String mac, BluetoothSocket socket) throws IOException {
-        return new BluetoothSerialDevice(mac, socket, socket.getOutputStream(), socket.getInputStream());
+    static BluetoothSerialDevice getInstance(String mac, BluetoothSocket socket, Charset charset) throws IOException {
+        return new BluetoothSerialDevice(mac, socket, socket.getOutputStream(), socket.getInputStream(), charset);
     }
 
     /**
@@ -54,7 +57,7 @@ public class BluetoothSerialDevice {
     public Flowable<String> openMessageStream() {
         requireNotClosed();
         return Flowable.create(emitter -> {
-            BufferedReader in = new BufferedReader(new InputStreamReader(inputStream));
+            BufferedReader in = new BufferedReader(new InputStreamReader(inputStream, charset));
             while (!emitter.isCancelled() && !closed) {
                 synchronized (this) {
                     try {

--- a/androidBluetoothSerial/src/main/java/com/harrysoft/androidbluetoothserial/BluetoothSerialDevice.java
+++ b/androidBluetoothSerial/src/main/java/com/harrysoft/androidbluetoothserial/BluetoothSerialDevice.java
@@ -47,7 +47,7 @@ public class BluetoothSerialDevice {
      */
     public Completable send(String message) {
         requireNotClosed();
-        return Completable.fromAction(() -> { if (!closed) outputStream.write(message.getBytes()); });
+        return Completable.fromAction(() -> { if (!closed) outputStream.write(message.getBytes(charset)); });
     }
 
     /**


### PR DESCRIPTION
This adds ability to specify charset when connecting to a device via `BluetoothManager.openSerialDevice(mac, charset)`·

In my use-case it lets me handle binary data coming over the serial connection by setting the charset to 'ISO-8859-1'.