### PR TITLE
Update BluetoothSerialDeviceImpl.kt

### DIFF
--- a/androidBluetoothSerial/src/main/java/com/harrysoft/androidbluetoothserial/BluetoothSerialDeviceImpl.kt
+++ b/androidBluetoothSerial/src/main/java/com/harrysoft/androidbluetoothserial/BluetoothSerialDeviceImpl.kt
@@ -60,12 +60,8 @@ internal class BluetoothSerialDeviceImpl constructor(
     fun close() {
         if (!closed.get()) {
             closed.set(true)
-            synchronized(inputStream) {
-                inputStream.close()
-            }
-            synchronized(outputStream) {
-                outputStream.close()
-            }
+            inputStream.close()
+            soutputStream.close()
             socket.close()
         }
         owner?.close()


### PR DESCRIPTION
Fix disconnecting from serial device.

There was no need to invoke methods with synchronized threads.